### PR TITLE
Strip anchors from URLs

### DIFF
--- a/lib/crawler/http_client/mock_client.ex
+++ b/lib/crawler/http_client/mock_client.ex
@@ -9,12 +9,19 @@ defmodule Crawler.HTTPClient.MockClient do
     }
     {:ok, response}
   end
-
   def get("http://mock/pdf", _opts) do
     response = %HTTPoison.Response{
       body: "<div><a href=\"/example\"></a></div>",
       status_code: 200,
       headers: [{"content-type", "file/pdf"}]
+    }
+    {:ok, response}
+  end
+  def get("http://mock/anchor_url", _opts) do
+    response = %HTTPoison.Response{
+      body: "<div><a href=\"/anchor_url#with-anchor\"></a></div>",
+      status_code: 200,
+      headers: [{"content-type", "text/html"}]
     }
     {:ok, response}
   end

--- a/lib/crawler/link/checker.ex
+++ b/lib/crawler/link/checker.ex
@@ -48,6 +48,7 @@ defmodule Crawler.Link.Checker do
     |> Floki.find("a")
     |> Floki.attribute("href")
     |> Enum.filter(&internal_link?(&1, base_url))
+    |> Enum.map(&strip_anchors/1)
     |> Enum.map(&Registry.add_link(link_path(&1, base_url), parent, depth))
   end
 
@@ -62,5 +63,10 @@ defmodule Crawler.Link.Checker do
 
   defp link_path(url, base_url) do
     String.trim(url, base_url)
+  end
+
+  defp strip_anchors(url) do
+    [trimmed_url | _anchors ] = String.split(url, "#")
+    trimmed_url
   end
 end

--- a/test/link/checker_test.exs
+++ b/test/link/checker_test.exs
@@ -7,7 +7,8 @@ defmodule Link.CheckerTest do
     {"/", nil, 0},
     {"/success_url", "/", 1},
     {"/pdf", "/", 1},
-    {"/error_url", "/", 1}
+    {"/error_url", "/", 1},
+    {"/anchor_url", "/", 1}
   ]
 
   setup do
@@ -39,7 +40,12 @@ defmodule Link.CheckerTest do
 
     test "Non HTML pages are not crawled for links" do
       verify_link("/pdf", "http://mock", 2)
-      refute "/example" in Registry.unchecked_links(3)
+      refute "/example" in Registry.unchecked_links(5)
+    end
+
+    test "Links with anchors are not registered as unique links" do
+      verify_link("/anchor_url", "http://mock", 2)
+      refute "/anchor_url#with-anchor" in Registry.unchecked_links(3)
     end
   end
 end

--- a/test/link/checker_test.exs
+++ b/test/link/checker_test.exs
@@ -40,7 +40,7 @@ defmodule Link.CheckerTest do
 
     test "Non HTML pages are not crawled for links" do
       verify_link("/pdf", "http://mock", 2)
-      refute "/example" in Registry.unchecked_links(5)
+      refute "/example" in Registry.unchecked_links(3)
     end
 
     test "Links with anchors are not registered as unique links" do


### PR DESCRIPTION
This strips out anchors from URLs during the link scraping phase. "/customer-support#info" should represent the same link as "/customer-support". This ensures the same link is not being checked multiple times. 