### PR TITLE
Use the default base URL if no arguments are defined

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ mix crawl <base_url>
 #### Options
 `--max-depth`: Maximum depth the scraper will travel. Defaults to 3.
 
-`--num-workers:` Maximum amount of concurrent workers making requests to the provided URL. Defaults to 5.
+`--workers:` Maximum amount of concurrent workers making requests to the provided URL. Defaults to 5.
 
 ### Installation
 In `mix.exs`

--- a/lib/mix/tasks/crawl.ex
+++ b/lib/mix/tasks/crawl.ex
@@ -18,7 +18,7 @@ defmodule Mix.Tasks.Crawl do
   defp parse_arguments(argv) do
     with {url, user_opts} <- from_argv(argv),
          {command_opts, _, _} <-
-           OptionParser.parse(user_opts, strict: [max_depth: :integer, num_workers: :integer]) do
+           OptionParser.parse(user_opts, strict: [max_depth: :integer, workers: :integer]) do
       if is_nil(url) do
         command_opts
       else


### PR DESCRIPTION
As it was, it would crash given no arguments, meaning the default URL
value of "http://localhost:4001" could never be reached.

Fix workers argument to match the value that is actually used.