### PR TITLE
Fix how we merge the base URL and relative path

### DIFF
--- a/lib/crawler/dispatcher.ex
+++ b/lib/crawler/dispatcher.ex
@@ -16,13 +16,16 @@ defmodule Crawler.Dispatcher do
   defp do_process_links(opts) do
     Registry.reset_dropped()
     task_opts = [timeout: 20_000, max_concurrency: opts[:workers]]
+
     for depth <- 0..opts[:max_depth] do
       verify = fn link -> Checker.verify_link(link, opts[:base_url], depth) end
+
       depth
       |> Registry.unchecked_links()
       |> Task.async_stream(verify, task_opts)
       |> Enum.map(& &1)
     end
+
     Registry.invalid_links()
   end
 

--- a/lib/crawler/http_client/mock_client.ex
+++ b/lib/crawler/http_client/mock_client.ex
@@ -1,28 +1,35 @@
 defmodule Crawler.HTTPClient.MockClient do
   @behaviour Crawler.HTTPClient
 
+  def get(%URI{} = url, opts), do: get(URI.to_string(url), opts)
+
   def get("http://mock/success_url", _opts) do
     response = %HTTPoison.Response{
       body: "<div><a href=\"/example\"></a></div>",
       status_code: 200,
       headers: [{"content-type", "text/html"}]
     }
+
     {:ok, response}
   end
+
   def get("http://mock/pdf", _opts) do
     response = %HTTPoison.Response{
       body: "<div><a href=\"/example\"></a></div>",
       status_code: 200,
       headers: [{"content-type", "file/pdf"}]
     }
+
     {:ok, response}
   end
+
   def get("http://mock/anchor_url", _opts) do
     response = %HTTPoison.Response{
       body: "<div><a href=\"/anchor_url#with-anchor\"></a></div>",
       status_code: 200,
       headers: [{"content-type", "text/html"}]
     }
+
     {:ok, response}
   end
 

--- a/lib/crawler/link/checker.ex
+++ b/lib/crawler/link/checker.ex
@@ -12,19 +12,19 @@ defmodule Crawler.Link.Checker do
   end
 
   def verify_link(link, base_url, depth) do
-    with url <- URI.merge(base_url, URI.encode(link)),
-         client <- Application.get_env(:crawler, :http_client, PoisonClient) do
-      case apply(client, :get, [url, [recv_timeout: 15_000]]) do
-        {:ok, %HTTPoison.Response{status_code: code} = response}
-        when code in 200..399 ->
-          handle_success(link, response, depth, base_url)
+    url = URI.merge(base_url, URI.encode(link))
+    client = Application.get_env(:crawler, :http_client, PoisonClient)
 
-        {:ok, %HTTPoison.Response{status_code: code}} ->
-          handle_error(link, code)
+    case apply(client, :get, [url, [recv_timeout: 15_000]]) do
+      {:ok, %HTTPoison.Response{status_code: code} = response}
+      when code in 200..399 ->
+        handle_success(link, response, depth, base_url)
 
-        {:error, %HTTPoison.Error{reason: reason}} ->
-          handle_error(link, reason)
-      end
+      {:ok, %HTTPoison.Response{status_code: code}} ->
+        handle_error(link, code)
+
+      {:error, %HTTPoison.Error{reason: reason}} ->
+        handle_error(link, reason)
     end
   end
 

--- a/test/link/checker_test.exs
+++ b/test/link/checker_test.exs
@@ -13,9 +13,11 @@ defmodule Link.CheckerTest do
 
   setup do
     {:ok, registry} = start_supervised(Crawler.Link.Registry)
+
     for {link, parent, depth} <- @initial_links do
       Registry.add_link(link, parent, depth)
     end
+
     %{registry: registry}
   end
 


### PR DESCRIPTION
Also, encode URI paths to safely handle characters like spaces.

This fixes a bug when using a trailing space in the base URL, as
reported in https://github.com/mbta/link-checker/pull/3.

I think with this we also no longer need https://github.com/mbta/link-checker/pull/3.