### PR TITLE
Decode URL paths before encoding them

### DIFF
--- a/lib/crawler/http_client/mock_client.ex
+++ b/lib/crawler/http_client/mock_client.ex
@@ -13,6 +13,16 @@ defmodule Crawler.HTTPClient.MockClient do
     {:ok, response}
   end
 
+  def get("http://mock/special%20characters", _opts) do
+    response = %HTTPoison.Response{
+      body: "<div><a href=\"/example\"></a></div>",
+      status_code: 200,
+      headers: [{"content-type", "text/html"}]
+    }
+
+    {:ok, response}
+  end
+
   def get("http://mock/pdf", _opts) do
     response = %HTTPoison.Response{
       body: "<div><a href=\"/example\"></a></div>",

--- a/lib/crawler/link/checker.ex
+++ b/lib/crawler/link/checker.ex
@@ -12,7 +12,7 @@ defmodule Crawler.Link.Checker do
   end
 
   def verify_link(link, base_url, depth) do
-    url = URI.merge(base_url, URI.encode(link))
+    url = URI.merge(base_url, link |> URI.decode() |> URI.encode())
     client = Application.get_env(:crawler, :http_client, PoisonClient)
 
     case apply(client, :get, [url, [recv_timeout: 15_000]]) do

--- a/test/link/checker_test.exs
+++ b/test/link/checker_test.exs
@@ -8,7 +8,9 @@ defmodule Link.CheckerTest do
     {"/success_url", "/", 1},
     {"/pdf", "/", 1},
     {"/error_url", "/", 1},
-    {"/anchor_url", "/", 1}
+    {"/anchor_url", "/", 1},
+    {"/special characters", "/", 1},
+    {"/special%20characters", "/", 1}
   ]
 
   setup do
@@ -32,6 +34,20 @@ defmodule Link.CheckerTest do
     test "links on successful link are added to processing list" do
       verify_link("/success_url", "http://mock", 2)
       assert "/example" in Registry.unchecked_links(3)
+    end
+
+    test "encodes special characters" do
+      verify_link("/special characters", "http://mock", 2)
+      invalid_urls = Registry.invalid_links() |> Enum.map(&elem(&1, 0))
+      refute "/special characters" in invalid_urls
+      refute "/special characters" in Registry.unchecked_links(2)
+    end
+
+    test "does not double-encode special characters" do
+      verify_link("/special%20characters", "http://mock", 2)
+      invalid_urls = Registry.invalid_links() |> Enum.map(&elem(&1, 0))
+      refute "/special%20characters" in invalid_urls
+      refute "/special%20characters" in Registry.unchecked_links(2)
     end
 
     test "unsuccessful link is marked with an error" do


### PR DESCRIPTION
To prevent double-encoding characters.