### PR TITLE
fix: Trim whitespace from links before navigating to them

### DIFF
--- a/lib/crawler/link/checker.ex
+++ b/lib/crawler/link/checker.ex
@@ -12,19 +12,21 @@ defmodule Crawler.Link.Checker do
   end
 
   def verify_link(link, base_url, depth) do
-    url = URI.merge(base_url, URI.encode(link))
+    trimmed_link = String.trim(link)
+    url = URI.merge(base_url, URI.encode(trimmed_link))
+
     client = Application.get_env(:crawler, :http_client, PoisonClient)
 
     case apply(client, :get, [url, [recv_timeout: 15_000]]) do
       {:ok, %HTTPoison.Response{status_code: code} = response}
       when code in 200..399 ->
-        handle_success(link, response, depth, base_url)
+        handle_success(trimmed_link, response, depth, base_url)
 
       {:ok, %HTTPoison.Response{status_code: code}} ->
-        handle_error(link, code)
+        handle_error(trimmed_link, code)
 
       {:error, %HTTPoison.Error{reason: reason}} ->
-        handle_error(link, reason)
+        handle_error(trimmed_link, reason)
     end
   end
 

--- a/lib/crawler/printer.ex
+++ b/lib/crawler/printer.ex
@@ -30,7 +30,7 @@ defmodule Crawler.Printer do
 
   def do_print_error(link, reason) do
     IO.write(IO.ANSI.red())
-    IO.puts("\nFAILED #{link}")
+    IO.puts("\nFAILED #{inspect(link)}")
     IO.puts("REASON: #{reason}")
     IO.write(IO.ANSI.default_color())
   end
@@ -48,9 +48,9 @@ defmodule Crawler.Printer do
   defp print_invalid_links(links) do
     IO.puts("Invalid Links:")
     for {_url, link} <- links do
-      IO.puts("\nURL: #{link.url}")
+      IO.puts("\nURL: #{inspect(link.url)}")
       IO.puts("Reason: #{inspect(elem(link.result, 1))}")
-      IO.puts("Parent: #{link.parent}")
+      IO.puts("Parent: #{inspect(link.parent)}")
       IO.puts("Depth: #{link.depth}")
     end
   end

--- a/test/link/checker_test.exs
+++ b/test/link/checker_test.exs
@@ -34,6 +34,11 @@ defmodule Link.CheckerTest do
       assert "/example" in Registry.unchecked_links(3)
     end
 
+    test "trailing spaces in links are trimmed" do
+      verify_link("/success_url ", "http://mock", 2)
+      assert "/example" in Registry.unchecked_links(3)
+    end
+
     test "unsuccessful link is marked with an error" do
       verify_link("/error_url", "http://mock", 2)
       invalid_urls = Registry.invalid_links() |> Enum.map(&elem(&1, 0))


### PR DESCRIPTION
The [web crawler action for Dotcom](https://github.com/mbta/dotcom/actions/workflows/crawler.yml) hasn't passed in months, and all but one of those failures are because there are links that have spaces in them.

This PR makes two changes related to that:
- Inspects the links (and the parent links) instead of `puts`'ing them, so that things like spaces are easier to see.
- Trims whitespace off of the links before checking them, since that's something all major browsers do seamlessly.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210063821006375