### PR TITLE
chore: Add shortdoc to `mix crawl` task

### DIFF
--- a/lib/mix/tasks/crawl.ex
+++ b/lib/mix/tasks/crawl.ex
@@ -6,6 +6,7 @@ defmodule Mix.Tasks.Crawl do
 
   def main(argv), do: run(argv)
 
+  @shortdoc "Crawl the site given"
   def run(argv) do
     Application.ensure_all_started(:httpoison)
     {:ok, _pid} = Crawler.Supervisor.start_link()


### PR DESCRIPTION
That way it will show up in the output of `mix help`.