### PR TITLE
fix: Allow this library to be used when Elixir version is 1.17

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Crawler.Mixfile do
     [
       app: :crawler,
       version: "0.2.0",
-      elixir: "~> 1.18",
+      elixir: "~> 1.17",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
Right now [the Dotcom Website Crawler GHA is failing](https://github.com/mbta/dotcom/actions/runs/14493568049/job/40655479288) because of an Elixir version mismatch. This 🤞should🤞 fix that.

```
** (Mix) You're trying to run :crawler on Elixir v1.17.0 but it has declared in its mix.exs file it supports only Elixir ~> 1.18
```

(TIL more about what the `elixir` version field in `mix.exs` does 😅)