### PR TITLE
chore: Allow this library to be used when Elixir version is 1.14

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Crawler.Mixfile do
     [
       app: :crawler,
       version: "0.2.0",
-      elixir: "~> 1.17",
+      elixir: "~> 1.14",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
Follow-up to https://github.com/mbta/link_checker/pull/12 - there's really no reason that we need to limit people to only Elixir 1.17 and later, when this isn't using any exciting new features.