### PR TITLE
fix: Trim whitespace from links before adding them to the registry

### DIFF
--- a/lib/crawler/http_client/mock_client.ex
+++ b/lib/crawler/http_client/mock_client.ex
@@ -13,6 +13,16 @@ defmodule Crawler.HTTPClient.MockClient do
     {:ok, response}
   end
 
+  def get("http://mock/spacy_success_url", _opts) do
+    response = %HTTPoison.Response{
+      body: "<div><a href=\"/example-with-space \"></a></div>",
+      status_code: 200,
+      headers: [{"content-type", "text/html"}]
+    }
+
+    {:ok, response}
+  end
+
   def get("http://mock/pdf", _opts) do
     response = %HTTPoison.Response{
       body: "<div><a href=\"/example\"></a></div>",

--- a/lib/crawler/link/checker.ex
+++ b/lib/crawler/link/checker.ex
@@ -12,21 +12,20 @@ defmodule Crawler.Link.Checker do
   end
 
   def verify_link(link, base_url, depth) do
-    trimmed_link = String.trim(link)
-    url = URI.merge(base_url, URI.encode(trimmed_link))
+    url = URI.merge(base_url, URI.encode(link))
 
     client = Application.get_env(:crawler, :http_client, PoisonClient)
 
     case apply(client, :get, [url, [recv_timeout: 15_000]]) do
       {:ok, %HTTPoison.Response{status_code: code} = response}
       when code in 200..399 ->
-        handle_success(trimmed_link, response, depth, base_url)
+        handle_success(link, response, depth, base_url)
 
       {:ok, %HTTPoison.Response{status_code: code}} ->
-        handle_error(trimmed_link, code)
+        handle_error(link, code)
 
       {:error, %HTTPoison.Error{reason: reason}} ->
-        handle_error(trimmed_link, reason)
+        handle_error(link, reason)
     end
   end
 
@@ -72,7 +71,9 @@ defmodule Crawler.Link.Checker do
   end
 
   defp link_path(url, base_url) do
-    String.trim(url, base_url)
+    url
+    |> String.trim(base_url)
+    |> String.trim()
   end
 
   defp strip_anchors(url) do

--- a/test/link/checker_test.exs
+++ b/test/link/checker_test.exs
@@ -6,6 +6,7 @@ defmodule Link.CheckerTest do
   @initial_links [
     {"/", nil, 0},
     {"/success_url", "/", 1},
+    {"/spacy_success_url", "/", 1},
     {"/pdf", "/", 1},
     {"/error_url", "/", 1},
     {"/anchor_url", "/", 1}
@@ -34,9 +35,9 @@ defmodule Link.CheckerTest do
       assert "/example" in Registry.unchecked_links(3)
     end
 
-    test "trailing spaces in links are trimmed" do
-      verify_link("/success_url ", "http://mock", 2)
-      assert "/example" in Registry.unchecked_links(3)
+    test "spaces on links are trimmed before being added to processing list" do
+      verify_link("/spacy_success_url", "http://mock", 2)
+      assert "/example-with-space" in Registry.unchecked_links(3)
     end
 
     test "unsuccessful link is marked with an error" do


### PR DESCRIPTION
The current Website Crawler builds are failing because of errors like this:
```
** (KeyError) key "/projects/transit-priority-strategy" not found in: %{
  "/projects/lynn-commuter-rail-station-improvements?utm_term=commuter-rail&utm_campaign=curated-content&utm_content=Lynn+Commuter+Rail+Station+Improvements&utm_medium=sidebar&utm_source=hub" => %Crawler.Link{
    url: "/projects/lynn-commuter-rail-station-improvements?utm_term=commuter-rail&utm_campaign=curated-content&utm_content=Lynn+Commuter+Rail+Station+Improvements&utm_medium=sidebar&utm_source=hub",
    parent: "/schedules/commuter-rail",
    depth: 2,
    result: :unknown
  },
  "/schedules/CR-Fitchburg" => %Crawler.Link{
    url: "/schedules/CR-Fitchburg",
    parent: "/schedules",
    depth: 2,
    result: :unknown
  },
 ...
```

That's because [this fix](https://github.com/mbta/link_checker/pull/8) trimmed whitespace off of links partway through their processing, so the link that was in the map was actually `"/projects/transit-priority-strategy "` (with the trailing whitespace).

This PR fixes that by trimming the whitespace off of the links before adding them to the link registry.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210063821006375