### PR TITLE
fix(Link.Checker): don't encode links

### DIFF
--- a/lib/crawler/link/checker.ex
+++ b/lib/crawler/link/checker.ex
@@ -12,7 +12,7 @@ defmodule Crawler.Link.Checker do
   end
 
   def verify_link(link, base_url, depth) do
-    url = URI.merge(base_url, URI.encode(link))
+    url = URI.merge(base_url, link)
 
     client = Application.get_env(:crawler, :http_client, PoisonClient)
 


### PR DESCRIPTION
Fixes 404 errors found by navigating the URI-encoded links directly to files.