### PR TITLE
feat(Crawler.Dispatcher): retry certain failures

### DIFF
--- a/lib/crawler/dispatcher.ex
+++ b/lib/crawler/dispatcher.ex
@@ -2,7 +2,7 @@ defmodule Crawler.Dispatcher do
   @moduledoc """
   Loops through remaining links and creates tasks to check those links for validity
   """
-  alias Crawler.{Link.Registry, Link.Checker, Printer}
+  alias Crawler.{Link, Link.Registry, Link.Checker, Printer}
 
   @default_opts [max_depth: 3, workers: 5, base_url: "http://localhost:4001"]
 
@@ -10,7 +10,29 @@ defmodule Crawler.Dispatcher do
     opts = Keyword.merge(@default_opts, user_opts)
     {time, invalid_links} = :timer.tc(fn -> do_process_links(opts) end)
     Printer.print_info(time, opts[:max_depth], invalid_links)
-    invalid_links |> pass_fail() |> System.halt()
+    uncertain_links = Enum.filter(invalid_links, &potentially_working?/1)
+
+    if length(uncertain_links) > 0 && opts[:workers] > 1 do
+      # Iterating over fewer links, and using fewer workers, results in fewer
+      # concurrent requests and less chance of being rate-limited.
+      IO.puts("""
+      \n#{length(uncertain_links)} links to retry: trying again, now with #{opts[:workers] - 1} workers.
+      """)
+
+      _ =
+        Enum.each(uncertain_links, fn {url, _link} ->
+          # Reset the result of affected links
+          Registry.update_link(url, :unknown)
+        end)
+
+      opts
+      |> Keyword.update!(:workers, &(&1 - 1))
+      |> process_links()
+    else
+      invalid_links
+      |> pass_fail()
+      |> System.halt()
+    end
   end
 
   defp do_process_links(opts) do
@@ -28,6 +50,11 @@ defmodule Crawler.Dispatcher do
 
     Registry.invalid_links()
   end
+
+  # Some responses might be flaky or transient.
+  defp potentially_working?({_path, %Link{result: {:error, 429}}}), do: true
+  defp potentially_working?({_path, %Link{result: {:error, :timeout}}}), do: true
+  defp potentially_working?(_), do: false
 
   defp pass_fail([]), do: 0
   defp pass_fail(_), do: 1


### PR DESCRIPTION
Sometimes the link checker gets rate limited. In that situation, and in situations where the page times out, we'd like to perform the check again to potentially avoid a false positive.

To do this, I adjusted the dispatcher logic:
- Checks the result in each invalid link. If the result indicates a timeout or a 429 response, we can retry it.
- The next attempt only operates over the remaining relevant invalid links
- The next attempt uses one fewer worker
- Keeps going until we run out of links, or 
- Keeps going until we run out of workers.

Tying the number of retries to the number of workers was a bit arbitrary, but I didn't want to add extra configuration for handling retries.

I am able to see the resulting change running the script locally -- in this example crawling dev-blue, two files which timed out succeeded on retry, ultimately resulting in 1 (valid) failure instead of 3 total failures reported.

<img width="1268" height="1522" alt="image" src="https://github.com/user-attachments/assets/4fbad666-a2bd-4a33-a332-59d9d549f323" />